### PR TITLE
README Separate out the instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# Using paint styles
-
-Paint styles are ways of changing how data is viewed in JOSM. You can use them to highlight certain things to fix, things that might not come up in the validation checks. 
-
-There’s a paint style you can add to JOSM to help you find a few errors that are common to HOT and Missing Maps tasks:
+A MapCSS paint style you can add to JOSM to help you find a few errors that are common to HOT and Missing Maps tasks:
  - buildings with names
  - buildings not tagged ``building=yes``
  - roads that are named
  - roads that are named for a description (like ``highway=residential``, ``name=residential``) 
  - buildings that are connected to roads or other features
 
-
 Like the validation warnings, the paint style doesn’t necessarily show what is wrong, but it shows what you’ll need to look at to see if it’s wrong.
+
+# Using paint styles
+
+Paint styles are ways of changing how data is viewed in JOSM. You can use them to highlight certain things to fix, things that might not come up in the validation checks. 
 
 To add the paint style, click on the Windows menu and go to Map Paint Styles… which will open a menu on JOSM:
 
@@ -22,7 +21,9 @@ Click the plus sign at upper right to add a new one.
 
 ![](https://i.imgur.com/fw04Miq.png)
 
-Type a name like Missing Maps Validation or whatever you'd like, and put https://github.com/MissingMaps/josm_styles/archive/master.zip in the URL field, and the paint style will appear in your Map Paint Styles window. 
+Type a name like Missing Maps Validation or whatever you'd like, and put https://github.com/MissingMaps/josm_styles/archive/master.zip in the URL field, and the paint style will appear in your Map Paint Styles window.
+
+# Errors and colors in this paint style
 
 There are four colors you may see from this paint style, corresponding to the errors mentioned earlier: 
  - buildings with names are yellow
@@ -32,7 +33,7 @@ There are four colors you may see from this paint style, corresponding to the er
  - buildings that are connected to roads or other features are red triangles
  - buildings that are connected to other buildings are orange triangles
 
-This paint style lets you got through and find these issues quickly and see if they should be fixed or not.
+This paint style lets you go through and find these issues quickly and see if they should be fixed or not.
 
 <img src="https://i.imgur.com/xLqP5Ah.png" width="600">
 <img src="http://i.imgur.com/7OHaoOj.png" width="400">


### PR DESCRIPTION
Move the information about what this is, to a top section to give a better at-a-glance overview of what the repo is. Separate out the instructions, also by adding a new heading at the bottom "Errors and colors in this paint style" for that further info which is not instructions.